### PR TITLE
Fix: missing 'unit_code' argument in AsyncOEClient get_facility_data method

### DIFF
--- a/openelectricity/client.py
+++ b/openelectricity/client.py
@@ -530,24 +530,26 @@ class AsyncOEClient(BaseOEClient):
     async def get_facility_data(
         self,
         network_code: NetworkCode,
-        facility_code: str | list[str],
-        metrics: list[DataMetric],
+        facility_code: str | list[str] | None = None,
+        metrics: list[DataMetric] | None = None,
         interval: DataInterval | None = None,
         date_start: datetime | None = None,
         date_end: datetime | None = None,
+        unit_code: str | list[str] | None = None,
     ) -> TimeSeriesResponse:
         """Get facility data for specified metrics."""
         logger.debug(
             "Getting facility data for %s/%s (metrics: %s, interval: %s)",
             network_code,
-            facility_code,
+            facility_code or unit_code,
             metrics,
             interval,
         )
         await self._ensure_client()
         params = {
             "facility_code": facility_code,
-            "metrics": [m.value for m in metrics],
+            "unit_code": unit_code,
+            "metrics": [m.value for m in metrics] if metrics else None,
             "interval": interval,
             "date_start": date_start.isoformat() if date_start else None,
             "date_end": date_end.isoformat() if date_end else None,

--- a/openelectricity/models/base.py
+++ b/openelectricity/models/base.py
@@ -6,11 +6,14 @@ This module contains the base models used across the API.
 
 from collections.abc import Sequence
 from datetime import datetime
+from typing import Generic, TypeVar
 
 from pydantic import BaseModel, Field
 
+T = TypeVar("T")
 
-class APIResponse[T](BaseModel):
+
+class APIResponse(BaseModel, Generic[T]):
     """Base API response model."""
 
     version: str


### PR DESCRIPTION
Hello!

I noticed the `AsyncOEClient.get_facility_data` class method was missing the `unit_code` argument. Was going to create an issue but realised it would be just as quick to fix it myself and create a PR :)

### Problem

Currently, the synchronous `OEClient` supports querying by `unit_code`, but the asynchronous implementation was missing this argument in its method signature, making it impossible to query specific units without hitting a 404 error when the unit code differs from the facility code.

### Solution

Added the `unit_code` argument to `AsyncOEClient.get_facility_data` and updated the method where necessary to account for this change (i.e. made the `facility_code` optional to allow for sole use of `unit_code`). The changes align with the synchronous implementation.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- If you are unable to check all the boxes, your pull request may not be eligible for review. -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules