### PR TITLE
feat(client): proxy and custom TLS/cert support (#22)

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,4 @@
+# gitignored files copied into `claude --worktree` worktrees so an isolated
+# checkout has a working dev environment (API key for tests, publish tokens).
+.env
+.envrc

--- a/openelectricity/client.py
+++ b/openelectricity/client.py
@@ -6,10 +6,11 @@ This module provides both synchronous and asynchronous clients for the OpenElect
 
 import asyncio
 import os
+import ssl
 from datetime import datetime
 from typing import Any, TypeVar, cast
 
-from aiohttp import ClientResponse, ClientSession
+from aiohttp import BasicAuth, ClientResponse, ClientSession, TCPConnector
 
 from openelectricity.logging import get_logger
 from openelectricity.models.facilities import FacilityResponse
@@ -54,9 +55,34 @@ class BaseOEClient:
         api_key: Optional API key for authentication. If not provided, will look for
                 OPENELECTRICITY_API_KEY environment variable.
         base_url: Optional base URL for the API. Defaults to production API.
+        proxy: Optional proxy URL (e.g. "http://proxy.corp:8080") for all requests.
+        proxy_auth: Optional aiohttp.BasicAuth for proxy authentication.
+        verify_ssl: Whether to verify TLS certificates. Defaults to True. Set to
+                False to disable verification (not recommended).
+        ssl_context: Optional pre-built ssl.SSLContext, e.g. for a corporate CA.
+        ca_cert: Optional path to a CA certificate bundle. A convenience over
+                ssl_context for the common "trust this extra CA" case.
+        trust_env: Whether aiohttp should read proxy settings, .netrc and TLS
+                config from the environment (HTTP_PROXY/HTTPS_PROXY etc).
+                Defaults to False.
+
+    Note:
+        ssl_context and ca_cert are mutually exclusive, and neither can be
+        combined with verify_ssl=False.
     """
 
-    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        *,
+        proxy: str | None = None,
+        proxy_auth: BasicAuth | None = None,
+        verify_ssl: bool = True,
+        ssl_context: ssl.SSLContext | None = None,
+        ca_cert: str | os.PathLike[str] | None = None,
+        trust_env: bool = False,
+    ) -> None:
         # Ensure base_url has a trailing slash for aiohttp ClientSession
         if base_url:
             self.base_url = base_url.rstrip("/") + "/"
@@ -77,7 +103,59 @@ class BaseOEClient:
             "Accept": "application/json",
             "Content-Type": "application/json",
         }
+
+        # Proxy and TLS configuration, applied in _build_session().
+        self.proxy = proxy
+        self.proxy_auth = proxy_auth
+        self.trust_env = trust_env
+        self._ssl = self._resolve_ssl(verify_ssl, ssl_context, ca_cert)
+
         logger.debug("Initialized client with base URL: %s", self.base_url)
+
+    @staticmethod
+    def _resolve_ssl(
+        verify_ssl: bool,
+        ssl_context: ssl.SSLContext | None,
+        ca_cert: str | os.PathLike[str] | None,
+    ) -> ssl.SSLContext | bool | None:
+        """Resolve TLS settings into a value for aiohttp's TCPConnector.
+
+        Returns None when defaults apply (no custom connector needed), False to
+        disable verification, or an SSLContext for a custom CA.
+        """
+        if ssl_context is not None and ca_cert is not None:
+            raise OpenElectricityError("Provide either ssl_context or ca_cert, not both")
+        if (ssl_context is not None or ca_cert is not None) and not verify_ssl:
+            raise OpenElectricityError("verify_ssl=False conflicts with a custom ssl_context/ca_cert")
+
+        if ssl_context is not None:
+            return ssl_context
+        if ca_cert is not None:
+            # Add the extra CA to the default trust store rather than
+            # replacing it (cafile= on create_default_context would drop the
+            # system CAs and break normal public TLS).
+            context = ssl.create_default_context()
+            context.load_verify_locations(cafile=os.fspath(ca_cert))
+            return context
+        if not verify_ssl:
+            return False
+        return None
+
+    def _build_session(self) -> ClientSession:
+        """Create a ClientSession with the configured proxy and TLS options.
+
+        Single point of session construction so proxy, custom certificates and
+        trust_env behaviour stay consistent across the sync and async clients.
+        """
+        connector = TCPConnector(ssl=self._ssl) if self._ssl is not None else None
+        return ClientSession(
+            base_url=self.base_url,
+            headers=self.headers,
+            trust_env=self.trust_env,
+            proxy=self.proxy,
+            proxy_auth=self.proxy_auth,
+            connector=connector,
+        )
 
 
 class OEClient(BaseOEClient):
@@ -88,8 +166,28 @@ class OEClient(BaseOEClient):
     API consistency while using the same underlying HTTP client as the async version.
     """
 
-    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
-        super().__init__(api_key, base_url)
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        *,
+        proxy: str | None = None,
+        proxy_auth: BasicAuth | None = None,
+        verify_ssl: bool = True,
+        ssl_context: ssl.SSLContext | None = None,
+        ca_cert: str | os.PathLike[str] | None = None,
+        trust_env: bool = False,
+    ) -> None:
+        super().__init__(
+            api_key,
+            base_url,
+            proxy=proxy,
+            proxy_auth=proxy_auth,
+            verify_ssl=verify_ssl,
+            ssl_context=ssl_context,
+            ca_cert=ca_cert,
+            trust_env=trust_env,
+        )
         self._session: ClientSession | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         logger.debug("Initialized synchronous client")
@@ -98,10 +196,7 @@ class OEClient(BaseOEClient):
         """Ensure session and event loop are initialized."""
         if self._session is None or self._session.closed:
             logger.debug("Creating new client session")
-            self._session = ClientSession(
-                base_url=self.base_url,
-                headers=self.headers,
-            )
+            self._session = self._build_session()
 
     async def _handle_response(self, response: ClientResponse) -> dict[str, Any] | list[dict[str, Any]]:
         """Handle API response and raise appropriate errors."""
@@ -288,7 +383,7 @@ class OEClient(BaseOEClient):
         """Get a list of facilities."""
 
         async def _run():
-            async with ClientSession(base_url=self.base_url, headers=self.headers) as session:
+            async with self._build_session() as session:
                 self._session = session
                 return await self._async_get_facilities(facility_code, status_id, fueltech_id, network_id, network_region)
 
@@ -327,7 +422,7 @@ class OEClient(BaseOEClient):
         """
 
         async def _run():
-            async with ClientSession(base_url=self.base_url, headers=self.headers) as session:
+            async with self._build_session() as session:
                 self._session = session
                 return await self._async_get_network_data(
                     network_code,
@@ -357,7 +452,7 @@ class OEClient(BaseOEClient):
         """Get facility data for specified metrics."""
 
         async def _run():
-            async with ClientSession(base_url=self.base_url, headers=self.headers) as session:
+            async with self._build_session() as session:
                 self._session = session
                 return await self._async_get_facility_data(
                     network_code, facility_code, metrics, interval, date_start, date_end, unit_code
@@ -378,7 +473,7 @@ class OEClient(BaseOEClient):
         """Get market data for specified metrics."""
 
         async def _run():
-            async with ClientSession(base_url=self.base_url, headers=self.headers) as session:
+            async with self._build_session() as session:
                 self._session = session
                 return await self._async_get_market(
                     network_code, metrics, interval, date_start, date_end, primary_grouping, network_region
@@ -390,7 +485,7 @@ class OEClient(BaseOEClient):
         """Get current user information."""
 
         async def _run():
-            async with ClientSession(base_url=self.base_url, headers=self.headers) as session:
+            async with self._build_session() as session:
                 self._session = session
                 return await self._async_get_current_user()
 
@@ -417,8 +512,28 @@ class AsyncOEClient(BaseOEClient):
     Asynchronous client for the OpenElectricity API.
     """
 
-    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
-        super().__init__(api_key, base_url)
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        *,
+        proxy: str | None = None,
+        proxy_auth: BasicAuth | None = None,
+        verify_ssl: bool = True,
+        ssl_context: ssl.SSLContext | None = None,
+        ca_cert: str | os.PathLike[str] | None = None,
+        trust_env: bool = False,
+    ) -> None:
+        super().__init__(
+            api_key,
+            base_url,
+            proxy=proxy,
+            proxy_auth=proxy_auth,
+            verify_ssl=verify_ssl,
+            ssl_context=ssl_context,
+            ca_cert=ca_cert,
+            trust_env=trust_env,
+        )
         self.client: ClientSession | None = None
         logger.debug("Initialized asynchronous client")
 
@@ -426,10 +541,7 @@ class AsyncOEClient(BaseOEClient):
         """Ensure client session is initialized."""
         if self.client is None or self.client.closed:
             logger.debug("Creating new async client session")
-            self.client = ClientSession(
-                base_url=self.base_url,
-                headers=self.headers,
-            )
+            self.client = self._build_session()
 
     async def _handle_response(self, response: ClientResponse) -> dict[str, Any] | list[dict[str, Any]]:
         """Handle API response and raise appropriate errors."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,9 @@ build-backend = "hatchling.build"
 path = "openelectricity/__init__.py"
 
 [tool.ruff]
-target-version = "py312"
+# Match requires-python (>=3.10) so lint never suggests 3.12-only syntax
+# such as PEP 695 generics, which break the advertised 3.10/3.11 support.
+target-version = "py310"
 line-length = 130
 exclude = [
   "docs",

--- a/tests/test_proxy_ssl.py
+++ b/tests/test_proxy_ssl.py
@@ -1,0 +1,84 @@
+"""
+Tests for proxy and TLS/certificate configuration (issue #22).
+
+These cover how OEClient/AsyncOEClient resolve proxy and SSL options and how
+they are applied to the underlying aiohttp ClientSession.
+"""
+
+import asyncio
+import ssl
+
+import pytest
+from aiohttp import BasicAuth
+
+from openelectricity import AsyncOEClient, OEClient
+from openelectricity.client import OpenElectricityError
+
+API_KEY = "test-key"
+
+
+def test_defaults_apply_no_custom_ssl_or_proxy() -> None:
+    """With no options, no custom connector/proxy is configured."""
+    client = OEClient(api_key=API_KEY)
+    assert client._ssl is None
+    assert client.proxy is None
+    assert client.proxy_auth is None
+    assert client.trust_env is False
+
+
+def test_verify_ssl_false_disables_verification() -> None:
+    client = OEClient(api_key=API_KEY, verify_ssl=False)
+    assert client._ssl is False
+
+
+def test_ssl_context_is_passed_through() -> None:
+    ctx = ssl.create_default_context()
+    client = OEClient(api_key=API_KEY, ssl_context=ctx)
+    assert client._ssl is ctx
+
+
+def test_ca_cert_builds_ssl_context() -> None:
+    cafile = ssl.get_default_verify_paths().cafile
+    if not cafile:
+        pytest.skip("no system CA bundle available to test against")
+    client = OEClient(api_key=API_KEY, ca_cert=cafile)
+    assert isinstance(client._ssl, ssl.SSLContext)
+
+
+def test_ssl_context_and_ca_cert_are_mutually_exclusive() -> None:
+    with pytest.raises(OpenElectricityError, match="not both"):
+        OEClient(api_key=API_KEY, ssl_context=ssl.create_default_context(), ca_cert="/tmp/ca.pem")
+
+
+def test_custom_ca_with_verify_disabled_is_rejected() -> None:
+    with pytest.raises(OpenElectricityError, match="conflicts"):
+        OEClient(api_key=API_KEY, verify_ssl=False, ca_cert="/tmp/ca.pem")
+
+
+def test_proxy_settings_are_stored() -> None:
+    auth = BasicAuth("user", "pass")
+    client = OEClient(api_key=API_KEY, proxy="http://proxy.corp:8080", proxy_auth=auth, trust_env=True)
+    assert client.proxy == "http://proxy.corp:8080"
+    assert client.proxy_auth is auth
+    assert client.trust_env is True
+
+
+def test_build_session_applies_proxy_and_trust_env() -> None:
+    """_build_session() wires proxy/trust_env onto the ClientSession."""
+    client = OEClient(api_key=API_KEY, proxy="http://proxy.corp:8080", trust_env=True)
+
+    async def _check() -> None:
+        session = client._build_session()
+        try:
+            assert "proxy.corp:8080" in str(session._default_proxy)
+            assert session._trust_env is True
+        finally:
+            await session.close()
+
+    asyncio.run(_check())
+
+
+def test_async_client_accepts_proxy_and_ssl_kwargs() -> None:
+    client = AsyncOEClient(api_key=API_KEY, proxy="http://proxy.corp:8080", verify_ssl=False)
+    assert client.proxy == "http://proxy.corp:8080"
+    assert client._ssl is False


### PR DESCRIPTION
Closes #22

## What

Proxy + TLS/cert configuration for `OEClient` / `AsyncOEClient`, for corporate-proxy and TLS-intercepting environments where requests currently fail with `ClientConnectorCertificateError`.

New keyword-only constructor options (sync + async):

| option | purpose |
|---|---|
| `proxy` | route all requests through an HTTP proxy |
| `proxy_auth` | `aiohttp.BasicAuth` for proxy auth |
| `ssl_context` | supply a pre-built `ssl.SSLContext` |
| `ca_cert` | add an extra CA bundle to the default trust store |
| `verify_ssl` | disable cert verification (escape hatch) |
| `trust_env` | let aiohttp read proxy / `.netrc` from the environment |

```python
client = OEClient(proxy="http://proxy.corp:8080", ca_cert="/etc/ssl/corp-ca.pem")
```

## How

- `BaseOEClient._build_session()` is now the single point of `ClientSession` construction, so proxy/TLS config stays consistent across the sync per-call sessions and the long-lived async session (addresses the "one factory function" ask in #22).
- `_resolve_ssl()` turns the options into an aiohttp connector `ssl` value. `ca_cert` is *added* to the system trust store (not replacing it). Conflicting `ssl_context` / `ca_cert` / `verify_ssl=False` combinations raise early.
- aiohttp 3.13's session-level `proxy`/`proxy_auth` kwargs mean no per-request call sites changed.

## Notes

- Backwards compatible: new options are keyword-only and default to current behaviour. `trust_env` defaults to `False` (aiohttp default), opt in for env-based proxy discovery.
- Bundled `chore(lint)`: ruff `target-version` -> `py310` so lint stops suggesting PEP 695 generics that break 3.10/3.11 (relates to #28).
- Bundled `.worktreeinclude` so `claude --worktree` copies `.env`/`.envrc`.

## Tests

`tests/test_proxy_ssl.py` (9 tests): option resolution, conflict validation, session wiring. Full suite (20) passes, ruff clean, py3.11 import verified.