### PR TITLE
fix(types): remove DataMetric.RENEWABLE_PROPORTION (use MarketMetric)

### DIFF
--- a/openelectricity/types.py
+++ b/openelectricity/types.py
@@ -36,13 +36,18 @@ class Network(StrEnum):
 
 
 class DataMetric(StrEnum):
-    """Data metrics available for network and facility data."""
+    """Data metrics available for network and facility data.
+
+    Note: ``renewable_proportion`` is a market-level metric and is only
+    available via :meth:`get_market` with
+    :attr:`MarketMetric.RENEWABLE_PROPORTION`. It is not exposed on
+    ``/data/network/`` and so is not listed here.
+    """
 
     POWER = "power"
     ENERGY = "energy"
     EMISSIONS = "emissions"
     MARKET_VALUE = "market_value"
-    RENEWABLE_PROPORTION = "renewable_proportion"
     STORAGE_BATTERY = "storage_battery"
 
 


### PR DESCRIPTION
Closes #18

## Diagnosis

`renewable_proportion` is a **market-level** metric. The API exposes it on `/market/network/` via `MarketMetric.RENEWABLE_PROPORTION` (shipped in v0.11.0). It is **not** exposed on `/data/network/`.

But the SDK also had it as `DataMetric.RENEWABLE_PROPORTION`, so users following the obvious pattern hit a confusing API error:

```python
# what users tried (issue #18)
c.get_network_data(metrics=[DataMetric.RENEWABLE_PROPORTION], ...)
# -> 400 Bad Request, no useful message
```

Verified live against prod:
- `DataMetric.RENEWABLE_PROPORTION` via `get_network_data` -> **400 Bad Request**
- `MarketMetric.RENEWABLE_PROPORTION` via `get_market` -> **OK** (48 hourly points, NEM ~32%)

## Fix

Drop the broken enum value from `DataMetric` so users can't reach the dead path. The `DataMetric` docstring now points to the working `MarketMetric` one.

## Backwards compat

Technically removes an enum value, but the value never produced anything but a 400 on prod (it was the dev-only metric @nc9 flagged in #18). No real code can have been relying on it.