### PR TITLE
feat(models): expose fueltech and renewable columns on TimeSeriesColumns

### DIFF
--- a/openelectricity/models/timeseries.py
+++ b/openelectricity/models/timeseries.py
@@ -31,10 +31,17 @@ class TimeSeriesDataPoint(RootModel):
 
 
 class TimeSeriesColumns(BaseModel):
-    """Column metadata for time series results."""
+    """Column metadata for time series results.
+
+    Populated according to the ``secondary_grouping`` used in the request:
+    ``fueltech`` / ``fueltech_group`` / ``renewable`` / ``unit_code`` /
+    ``network_region``.
+    """
 
     unit_code: str | None = None
+    fueltech: str | None = None
     fueltech_group: str | None = None
+    renewable: bool | None = None
     network_region: str | None = None
 
 

--- a/tests/models/test_timeseries.py
+++ b/tests/models/test_timeseries.py
@@ -195,3 +195,36 @@ def test_invalid_interval():
                 "network_timezone_offset": "+10:00",
             }
         )
+
+
+def test_columns_fueltech_populated_when_grouping_by_fueltech() -> None:
+    """secondary_grouping=fueltech sets the fueltech column (issue surfaced
+    while validating #8)."""
+    result = TimeSeriesResult.model_validate(
+        {
+            "name": "energy_solar_rooftop",
+            "date_start": "2026-05-22T00:00:00+10:00",
+            "date_end": "2026-05-23T00:00:00+10:00",
+            "columns": {"fueltech": "solar_rooftop"},
+            "data": [["2026-05-22T00:00:00+10:00", 48000.0]],
+        }
+    )
+    assert result.columns.fueltech == "solar_rooftop"
+    assert result.columns.fueltech_group is None
+    assert result.columns.renewable is None
+
+
+def test_columns_renewable_populated_when_grouping_by_renewable() -> None:
+    """secondary_grouping=renewable sets the renewable boolean column."""
+    result = TimeSeriesResult.model_validate(
+        {
+            "name": "energy_True",
+            "date_start": "2026-05-22T00:00:00+10:00",
+            "date_end": "2026-05-23T00:00:00+10:00",
+            "columns": {"renewable": True},
+            "data": [["2026-05-22T00:00:00+10:00", 250000.0]],
+        }
+    )
+    assert result.columns.renewable is True
+    assert result.columns.fueltech is None
+    assert result.columns.fueltech_group is None


### PR DESCRIPTION
Surfaced while validating #8: calling \`get_network_data(secondary_grouping='fueltech' | 'renewable')\` returns the grouping in the result's \`columns\` object, but \`TimeSeriesColumns\` only declared \`unit_code\`, \`fueltech_group\` and \`network_region\` — so the actual grouping value was silently dropped on parse and users had to fish it out of \`result.name\` (\`\"energy_solar_rooftop\"\`).

## Change

\`\`\`python
class TimeSeriesColumns(BaseModel):
    unit_code: str | None = None
    fueltech: str | None = None         # NEW
    fueltech_group: str | None = None
    renewable: bool | None = None       # NEW
    network_region: str | None = None
\`\`\`

## Verified

- 2 new parse tests in \`tests/models/test_timeseries.py\`.
- Live against prod and dev for both groupings — column now populates correctly (e.g. \`fueltech='battery'\`, \`renewable=False\`).

## Out of scope

\`secondary_grouping='status'\` returns a 500 from the API (separate server-side bug). Worth a tracking issue in \`opennem/opennem\`.