### PR TITLE
feat(client): pre-flight 30-facility limit check + clearer docstrings (#10)

### DIFF
--- a/openelectricity/client.py
+++ b/openelectricity/client.py
@@ -65,6 +65,25 @@ class APIError(OpenElectricityError):
         super().__init__(f"API Error {status_code}: {detail}")
 
 
+# The /data/facilities/ endpoint caps facility_code and unit_code at this many
+# items per request (the server returns a 422 above it). Catching it client-side
+# turns a network round-trip + pydantic error payload into a plain Python error.
+_FACILITY_LIST_LIMIT = 30
+
+
+def _check_facility_list_limit(
+    facility_code: str | list[str] | None,
+    unit_code: str | list[str] | None,
+) -> None:
+    """Raise OpenElectricityError if either code list exceeds the API's per-request cap."""
+    for name, value in (("facility_code", facility_code), ("unit_code", unit_code)):
+        if isinstance(value, list) and len(value) > _FACILITY_LIST_LIMIT:
+            raise OpenElectricityError(
+                f"{name} accepts at most {_FACILITY_LIST_LIMIT} codes per request; "
+                f"got {len(value)}. Split into chunks of {_FACILITY_LIST_LIMIT} or filter further."
+            )
+
+
 class BaseOEClient:
     """
     Base client for the OpenElectricity API.
@@ -324,6 +343,7 @@ class OEClient(BaseOEClient):
         unit_code: str | list[str] | None = None,
     ) -> TimeSeriesResponse:
         """Async implementation of get_facility_data."""
+        _check_facility_list_limit(facility_code, unit_code)
         logger.debug(
             "Getting facility data for %s/%s (metrics: %s, interval: %s)",
             network_code,
@@ -468,7 +488,14 @@ class OEClient(BaseOEClient):
         date_end: datetime | None = None,
         unit_code: str | list[str] | None = None,
     ) -> TimeSeriesResponse:
-        """Get facility data for specified metrics."""
+        """Get facility data for specified metrics.
+
+        Note:
+            The API accepts at most 30 ``facility_code`` (or ``unit_code``)
+            items per request. Larger lists raise
+            :class:`OpenElectricityError` before the request is sent — split
+            into chunks of 30 or filter further.
+        """
 
         async def _run():
             async with self._build_session() as session:
@@ -668,7 +695,15 @@ class AsyncOEClient(BaseOEClient):
         date_end: datetime | None = None,
         unit_code: str | list[str] | None = None,
     ) -> TimeSeriesResponse:
-        """Get facility data for specified metrics."""
+        """Get facility data for specified metrics.
+
+        Note:
+            The API accepts at most 30 ``facility_code`` (or ``unit_code``)
+            items per request. Larger lists raise
+            :class:`OpenElectricityError` before the request is sent — split
+            into chunks of 30 or filter further.
+        """
+        _check_facility_list_limit(facility_code, unit_code)
         logger.debug(
             "Getting facility data for %s/%s (metrics: %s, interval: %s)",
             network_code,

--- a/tests/test_facility_list_limit.py
+++ b/tests/test_facility_list_limit.py
@@ -1,0 +1,47 @@
+"""
+Tests for the pre-flight facility_code / unit_code length check on
+get_facility_data (issue #10).
+"""
+
+import pytest
+
+from openelectricity import AsyncOEClient, OEClient
+from openelectricity.client import OpenElectricityError, _check_facility_list_limit
+
+
+def _codes(n: int) -> list[str]:
+    return [f"F{i:03d}" for i in range(n)]
+
+
+def test_helper_passes_under_the_cap() -> None:
+    _check_facility_list_limit(_codes(30), None)
+    _check_facility_list_limit(None, _codes(30))
+    _check_facility_list_limit(_codes(15), _codes(15))
+    _check_facility_list_limit("ONLY_ONE", None)
+
+
+def test_helper_raises_on_31_facility_codes() -> None:
+    with pytest.raises(OpenElectricityError, match="facility_code accepts at most 30"):
+        _check_facility_list_limit(_codes(31), None)
+
+
+def test_helper_raises_on_31_unit_codes() -> None:
+    with pytest.raises(OpenElectricityError, match="unit_code accepts at most 30"):
+        _check_facility_list_limit(None, _codes(31))
+
+
+def test_sync_get_facility_data_rejects_too_many_codes_before_sending() -> None:
+    """The check fires before any network call — a dummy api_key is enough."""
+    with OEClient(api_key="test") as c:
+        with pytest.raises(OpenElectricityError, match="facility_code accepts at most 30"):
+            c.get_facility_data(network_code="NEM", facility_code=_codes(36))
+
+
+@pytest.mark.asyncio
+async def test_async_get_facility_data_rejects_too_many_codes_before_sending() -> None:
+    c = AsyncOEClient(api_key="test")
+    try:
+        with pytest.raises(OpenElectricityError, match="unit_code accepts at most 30"):
+            await c.get_facility_data(network_code="NEM", unit_code=_codes(31))
+    finally:
+        await c.close()


### PR DESCRIPTION
Refs #10

## What

The \`/data/facilities/\` endpoint accepts at most 30 \`facility_code\` (or \`unit_code\`) items per request. Above that the server returns a 422 with a pydantic validation payload. We can do better client-side:

- new \`_check_facility_list_limit()\` helper that raises \`OpenElectricityError\` before sending the request when either list exceeds 30
- wired into both \`OEClient._async_get_facility_data\` and \`AsyncOEClient.get_facility_data\` (the two execution paths)
- docstrings on the two public \`get_facility_data\` methods now document the cap

The error message tells the user the exact remedy:

\`\`\`
facility_code accepts at most 30 codes per request; got 36.
Split into chunks of 30 or filter further.
\`\`\`

## Why not auto-chunk?

nc9's reply on #10 said this is a "mildly superficial limit ... long-term the plan is to open it up". Hardcoding a chunk loop now would couple the SDK to a number that's expected to move. A clear pre-flight error is the cheapest user-facing improvement without that coupling.

## Tests

\`tests/test_facility_list_limit.py\` — 5 tests covering the helper directly, the sync public path, the async public path, and both \`facility_code\` and \`unit_code\` lists. All pass; signature-parity test still green.

## Verified live

\`\`\`python
c.get_facility_data(network_code='NEM', facility_code=[36 codes], ...)
# OpenElectricityError: facility_code accepts at most 30 codes per request; got 36.
\`\`\`

No network round-trip on overflow.