### PR TITLE
fix(client): use OS resolver instead of aiodns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,21 @@ concurrency:
 
 jobs:
   test:
-    name: test (py${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }} py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        # DNS resolver / event-loop behaviour differs per OS (the aiodns
+        # ProactorEventLoop failure only repros on Windows); cover Windows +
+        # macOS on the latest Python without the full cross-product.
+        include:
+          - os: windows-latest
+            python-version: "3.13"
+          - os: macos-latest
+            python-version: "3.13"
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.11.3
 
 ### Added
 
@@ -9,6 +9,17 @@
   (30), with a message naming the param and the limit. Avoids a
   round-trip + the server-side 422 payload. Docstrings updated to
   document the cap. (#10, #36)
+
+### Fixed
+
+- DNS resolution now uses the OS resolver (`ThreadedResolver`/`getaddrinfo`)
+  instead of aiodns. The `aiohttp[speedups]` extra installs aiodns, which made
+  aiohttp default to the c-ares `AsyncResolver`. c-ares resolves DNS
+  independently of the OS stub resolver and failed with
+  `aiodns.error.DNSError (11, 'Could not contact DNS servers')` in
+  environments where the OS resolver (and `nslookup`) work fine — Windows
+  `ProactorEventLoop`, WSL/containers pointing at `127.0.0.53`, split-DNS
+  VPNs. The connector is now pinned to `ThreadedResolver`.
 
 ## 0.11.2
 

--- a/openelectricity/__init__.py
+++ b/openelectricity/__init__.py
@@ -19,7 +19,7 @@ from openelectricity.types import (
 
 __name__ = "openelectricity"
 
-__version__ = "0.11.2"
+__version__ = "0.11.3"
 
 __all__ = [
     "OEClient",

--- a/openelectricity/client.py
+++ b/openelectricity/client.py
@@ -12,7 +12,7 @@ from collections.abc import Coroutine
 from datetime import datetime
 from typing import Any, TypeVar, cast
 
-from aiohttp import BasicAuth, ClientResponse, ClientSession, TCPConnector
+from aiohttp import BasicAuth, ClientResponse, ClientSession, TCPConnector, ThreadedResolver
 
 from openelectricity.logging import get_logger
 from openelectricity.models.facilities import FacilityResponse
@@ -184,7 +184,17 @@ class BaseOEClient:
         Single point of session construction so proxy, custom certificates and
         trust_env behaviour stay consistent across the sync and async clients.
         """
-        connector = TCPConnector(ssl=self._ssl) if self._ssl is not None else None
+        # Force the threaded (OS getaddrinfo) resolver. The aiohttp[speedups]
+        # extra installs aiodns, which makes aiohttp default to the c-ares
+        # AsyncResolver. c-ares resolves DNS independently of the OS stub
+        # resolver and fails in environments where getaddrinfo (and nslookup)
+        # work fine — Windows ProactorEventLoop, WSL/containers pointing at
+        # 127.0.0.53, split-DNS VPNs — raising
+        # aiodns.error.DNSError (11, 'Could not contact DNS servers').
+        connector = TCPConnector(
+            resolver=ThreadedResolver(),
+            ssl=self._ssl if self._ssl is not None else True,
+        )
         return ClientSession(
             base_url=self.base_url,
             headers=self.headers,

--- a/tests/test_proxy_ssl.py
+++ b/tests/test_proxy_ssl.py
@@ -78,6 +78,28 @@ def test_build_session_applies_proxy_and_trust_env() -> None:
     asyncio.run(_check())
 
 
+def test_build_session_uses_threaded_resolver() -> None:
+    """DNS goes through the OS resolver, not aiodns/c-ares.
+
+    aiohttp[speedups] installs aiodns and aiohttp then defaults to the c-ares
+    AsyncResolver, which fails (DNSError 11, 'Could not contact DNS servers')
+    in environments where getaddrinfo works fine. Pin ThreadedResolver so the
+    SDK resolves DNS the same way the OS does.
+    """
+    from aiohttp.resolver import ThreadedResolver
+
+    client = OEClient(api_key=API_KEY)
+
+    async def _check() -> None:
+        session = client._build_session()
+        try:
+            assert isinstance(session.connector._resolver, ThreadedResolver)
+        finally:
+            await session.close()
+
+    asyncio.run(_check())
+
+
 def test_async_client_accepts_proxy_and_ssl_kwargs() -> None:
     client = AsyncOEClient(api_key=API_KEY, proxy="http://proxy.corp:8080", verify_ssl=False)
     assert client.proxy == "http://proxy.corp:8080"


### PR DESCRIPTION
## what

user of the python sdk hit `aiodns.error.DNSError: (11, 'Could not contact DNS servers')` on every authorised request, while `nslookup` in the same env worked fine. no vpn/proxy.

## why

`aiohttp[speedups]` pulls in aiodns, so aiohttp defaults its resolver to the c-ares `AsyncResolver`. c-ares resolves dns independently of the OS stub resolver and fails where `getaddrinfo`/`nslookup` work fine — windows ProactorEventLoop, wsl/containers on 127.0.0.53, split-dns vpns. that 'nslookup ok, app fails' split is the signature.

## fix

- pin `TCPConnector` to `ThreadedResolver()` (OS getaddrinfo) in `_build_session` — same path the OS uses. keeps speedups (brotli) but never touches aiodns.
- unit test asserts the connector resolver is `ThreadedResolver`.
- bump 0.11.2 -> 0.11.3.

## ci

- add windows-latest + macos-latest (py3.13) to the test matrix. resolver/event-loop bugs are OS-specific and ubuntu-only CI couldn't catch this class. the new windows job runs the resolver assertion on the OS where it actually mattered.

separate commits: fix, then ci.